### PR TITLE
feat: add blueprint terminal UI skeleton

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders AI Tactical Feedback heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/AI Tactical Feedback/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Switch,
   Tab,
   Tabs,
+  TabId,
 } from '@blueprintjs/core';
 
 interface AIResponse {
@@ -68,8 +69,8 @@ export default function App() {
             id="main-nav"
             vertical
             selectedTabId={tabId}
-            onChange={(id) => setTabId(id as string)}
-            renderActiveTabPanel={false}
+            onChange={(newId: TabId) => setTabId(newId.toString())}
+            renderActiveTabPanelOnly
           >
             <Tab id="dashboard" title="Dashboard" />
             <Tab id="log" title="Log" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,55 +1,140 @@
-// BlueprintJS Terminal-Themed Web App (Mock + Stubbed Backend)
-// Tailored for Tomcat + DeepSeek future interop
-
-import React from 'react';
+import React, { useState } from 'react';
 import {
-  Button, Card, Elevation, Navbar, Alignment, Switch, Tabs, Tab
-} from "@blueprintjs/core";
-import "@blueprintjs/core/lib/css/blueprint.css";
+  Alignment,
+  Button,
+  Card,
+  Classes,
+  Elevation,
+  Navbar,
+  Switch,
+  Tab,
+  Tabs,
+} from '@blueprintjs/core';
 
-// Mock response for /api/infer (DeepSeek)
-const mockAIResponse = {
-  input: "Deploy unit to eastern ridge",
-  output: "Simulated: Tactical position reinforced. Terrain advantageous under current light conditions.",
-  reasoning: "Inductive heuristic analysis",
-  timestamp: new Date().toLocaleString(),
+interface AIResponse {
+  input: string;
+  output: string;
+  reasoning: string;
+  timestamp: string;
+}
+
+const mockResponses: Omit<AIResponse, 'timestamp'>[] = [
+  {
+    input: 'Deploy unit to eastern ridge',
+    output:
+      'Simulated: Tactical position reinforced. Terrain advantageous under current light conditions.',
+    reasoning: 'Inductive heuristic analysis',
+  },
+  {
+    input: 'Scan sector for movement',
+    output:
+      'Simulated: No hostiles detected. Thermal signatures stable across grid.',
+    reasoning: 'Infrared sweep heuristic',
+  },
+  {
+    input: 'Run supply check on battalion',
+    output:
+      'Simulated: Munitions at 84%. Fuel reserves nominal. Suggested resupply in 12h.',
+    reasoning: 'Inventory delta projection',
+  },
+];
+
+const simulateResponse = (): AIResponse => {
+  const base = mockResponses[Math.floor(Math.random() * mockResponses.length)];
+  return { ...base, timestamp: new Date().toLocaleString() };
 };
 
-export default function TerminalApp() {
-  const [darkMode, setDarkMode] = React.useState(true);
-  const [aiResponse, setAIResponse] = React.useState(mockAIResponse);
+export default function App() {
+  const [darkMode, setDarkMode] = useState(true);
+  const [aiResponse, setAIResponse] = useState<AIResponse>(simulateResponse());
+  const [tabId, setTabId] = useState<string>('dashboard');
 
-  const toggleTheme = () => setDarkMode(!darkMode);
+  const handleSimulate = () => setAIResponse(simulateResponse());
 
   return (
-    <div className={darkMode ? "bp5-dark" : ""} style={{ display: "flex", height: "100vh", fontFamily: "'Stolzl', sans-serif" }}>
-      <Navbar style={{ width: "240px", minHeight: "100vh", opacity: 0.9 }}>
-        <Navbar.Group align={Alignment.LEFT}>
-          <Navbar.Heading>⚔️ Layer-4 Terminal</Navbar.Heading>
-          <Navbar.Divider />
-          <Tabs id="MainNav" vertical defaultSelectedTabId="dashboard">
+    <div
+      className={darkMode ? Classes.DARK : ''}
+      style={{ display: 'flex', height: '100vh', fontFamily: "'Stolzl','Roboto',sans-serif" }}
+    >
+      <Navbar style={{ width: 200, minHeight: '100vh', opacity: 0.9 }}>
+        <Navbar.Group
+          align={Alignment.LEFT}
+          style={{ flexDirection: 'column', alignItems: 'flex-start' }}
+        >
+          <Navbar.Heading style={{ fontSize: '1rem', marginBottom: '1rem' }}>
+            ⚔ Layer-4 Terminal
+          </Navbar.Heading>
+          <Tabs
+            id="main-nav"
+            vertical
+            selectedTabId={tabId}
+            onChange={(id) => setTabId(id as string)}
+            renderActiveTabPanel={false}
+          >
             <Tab id="dashboard" title="Dashboard" />
-            <Tab id="history" title="Log" />
+            <Tab id="log" title="Log" />
             <Tab id="settings" title="Settings" />
           </Tabs>
           <Switch
             label="Dark Mode"
             checked={darkMode}
-            onChange={toggleTheme}
-            style={{ marginTop: "2rem" }}
+            onChange={() => setDarkMode(!darkMode)}
+            style={{ marginTop: 'auto' }}
           />
         </Navbar.Group>
       </Navbar>
 
-      <div style={{ flexGrow: 1, padding: "2rem", backgroundColor: darkMode ? "#10161A" : "#F5F8FA" }}>
-        <Card elevation={Elevation.TWO} style={{ opacity: 0.95 }}>
-          <h2 style={{ marginBottom: "1rem" }}>AI Tactical Feedback</h2>
-          <p><strong>Input:</strong> {aiResponse.input}</p>
-          <p><strong>Response:</strong> {aiResponse.output}</p>
-          <p><strong>Reasoning:</strong> {aiResponse.reasoning}</p>
-          <p><em>Timestamp:</em> {aiResponse.timestamp}</p>
-          <Button intent="primary" text="Simulate Another" onClick={() => setAIResponse(mockAIResponse)} />
-        </Card>
+      <div
+        style={{
+          flexGrow: 1,
+          padding: '2rem',
+          backgroundColor: darkMode ? '#10161A' : '#F5F8FA',
+        }}
+      >
+        {tabId === 'dashboard' && (
+          <>
+            <Card elevation={Elevation.TWO} style={{ opacity: 0.95, marginBottom: '1rem' }}>
+              <h2 style={{ marginBottom: '1rem' }}>AI Tactical Feedback</h2>
+              <p>
+                <strong>Input:</strong> {aiResponse.input}
+              </p>
+              <p>
+                <strong>Response:</strong> {aiResponse.output}
+              </p>
+              <p>
+                <strong>Reasoning:</strong> {aiResponse.reasoning}
+              </p>
+              <p>
+                <em>Timestamp:</em> {aiResponse.timestamp}
+              </p>
+              <Button intent="primary" text="Simulate Another" onClick={handleSimulate} />
+            </Card>
+            <Card elevation={Elevation.ONE} style={{ opacity: 0.9 }}>
+              <h3>Tomcat Monitor</h3>
+              <p>Placeholder for server metrics...</p>
+            </Card>
+          </>
+        )}
+
+        {tabId === 'log' && (
+          <Card elevation={Elevation.ONE} style={{ opacity: 0.9 }}>
+            <h3>Log</h3>
+            <p>Placeholder: AI interaction history will appear here.</p>
+          </Card>
+        )}
+
+        {tabId === 'settings' && (
+          <Card elevation={Elevation.ONE} style={{ opacity: 0.9 }}>
+            <h3>Settings</h3>
+            <p>Future-ready stubs:</p>
+            <ul>
+              <li>Reverb-Net GPT selector</li>
+              <li>EPOCH tree selection</li>
+              <li>Local cache for auth/session keys</li>
+              <li>Story Arc scenario picker</li>
+            </ul>
+          </Card>
+        )}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap');
 @import "@blueprintjs/core/lib/css/blueprint.css";
 @import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Stolzl', 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,17 +3,13 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import TerminalApp from './App';
-
-
-
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <TerminalApp />
+    <App />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- build terminal-style dashboard using BlueprintJS with vertical tabs, theme toggle, and mock AI output cards
- add placeholders for Tomcat monitor and future settings stubs
- wire up index entry and fonts for Stolzl/Roboto

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e4c454ec8324ab2f41ff8410042e